### PR TITLE
compat-5.3.h: add Lua 5.4 support

### DIFF
--- a/compat-5.3.h
+++ b/compat-5.3.h
@@ -397,11 +397,11 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 503
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
 
-#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, or 5.3)"
+#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3 or 5.4)"
 
-#endif /* other Lua versions except 5.1, 5.2, and 5.3 */
+#endif /* other Lua versions except 5.1, 5.2, 5.3 and 5.4 */
 
 
 


### PR DESCRIPTION
Fix the following build failure with Lua 5.4:

```
In file included from lsyslog.c:11:
compat-5.3.h:402:4: error: #error "unsupported Lua version (i.e. not Lua 5.1, 5.2, or 5.3)"
  402 | #  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, or 5.3)"
      |    ^~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/df2aabcf2ae07cad66b869ec4ac76702d2c32dc5

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>